### PR TITLE
Updating .gitignore due to file structure change

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,7 +1,7 @@
-LM\ IR\ BLinker.X/build/*
-LM\ IR\ BLinker.X/dist/*
-LM\ IR\ BLinker.X/nbproject/*
-LM\ IR\ BLinker.X/debug/*
+build/*
+dist/*
+nbproject/*
+debug/*
 
-!LM\ IR\ BLinker.X/nbproject/configurations.xml
-!LM\ IR\ BLinker.X/nbproject/project.xml
+!nbproject/configurations.xml
+!nbproject/project.xml


### PR DESCRIPTION
Updating the list of files for git to ignore:

| Directory to ignore | Description |
|--------|-------------------------------------------------------------------------------------------------------------------------|
| build | The directory where MPLAB X sticks intermediate files made during the compiling process |
| dist | The directory where MPLAB X sticks the final binary that is used to flash the microcontroller |
| debug | Same as dist, except this contains the final binary that's used when you "debug" the microcontroller |
| nbproject | All of the files that describe the project within MPLAB X. Settings, etc. Since MPLAB X is built on top of a platform called NetBeans, this folder is called nbproject for "NetBeans Project". Not very classy if you ask me... |

There are two exceptions that we want to keep out of those folders that we ignored. So we list those with the `!` or "not" character:

 - nbproject/configurations.xml: We need to keep track of this one because it describes which *.c and *.h files need to be linked together.
 - nbproject/project.xml: We need to keep track of this one because it stores the relative file paths of where the *.c and *.h files are.

We don't need to keep track of the other nbproject files because it's a whole bunch of generic garbage that MPLAB X figures out automatically. Since it's not important to us and doesn't change, we don't need to track it, look at it, or think about it.

We also don't want to keep track of the compiled output, we only care about the source code.