### PR TITLE
32bit data

### DIFF
--- a/main.c
+++ b/main.c
@@ -17,13 +17,13 @@ const bool preamble[] = {1, 1, 1, 0, 1, 1, 0, 0, 0, 0,
                          1, 1, 1, 0, 1, 1, 0, 0, 0, 0};       // Preamble
 bool data[DATA_LENGTH] = {0};                                 // Data of our packet                             
 const bool delayBetweenTransmissions[61] = {0};               // Fill an array of zeros
-bool* arrayStartPtr = NULL;                                   // Points to the beginning of an array
+const bool* arrayStartPtr = NULL;                             // Points to the beginning of an array
 uint8_t bitIndex = 0;                                         // Keeps track of our bit position
 
 
 // ========== FUNCTION PROTOTYPES ==========
 void bitTimerInterrupt();
-void transmitBits(bool* arrayStart, uint8_t size);
+void transmitBits(const bool* arrayStart, uint8_t size);
 void setDataPattern(uint32_t newDataPattern);
 void stepThroughDataPatterns(uint16_t repeatEachPatternNTimes);
 
@@ -68,7 +68,7 @@ void bitTimerInterrupt() {
 }
 
 
-void transmitBits(bool* arrayStart, uint8_t size) {
+void transmitBits(const bool* arrayStart, uint8_t size) {
   bitIndex = 0;               // Re-initialize bit index
   arrayStartPtr = arrayStart; // Point to the start of the array we want to transmit
   while(bitIndex < size);     // Wait here until the bit index reaches the end of the array

--- a/main.c
+++ b/main.c
@@ -6,6 +6,10 @@
 
 #define LED_PIN     LATAbits.LATA3      // Write to this to force the pin high (1) or low (0)
 #define PWM_EN      PWM3CONbits.EN      // Enables (1) or Disables (0) the PWM Output
+
+#if DATA_LENGTH > 32
+    #error "Data length has to be 32 bits or less"
+#endif
  
 
 // ========== GLOBAL VARIABLES ==========
@@ -20,7 +24,7 @@ uint8_t bitIndex = 0;                                         // Keeps track of 
 // ========== FUNCTION PROTOTYPES ==========
 void bitTimerInterrupt();
 void transmitBits(bool* arrayStart, uint8_t size);
-void setDataPattern(uint16_t newDataPattern);
+void setDataPattern(uint32_t newDataPattern);
 void stepThroughDataPatterns(uint16_t repeatEachPatternNTimes);
 
 // ========== MAIN ==========
@@ -74,7 +78,7 @@ void transmitBits(bool* arrayStart, uint8_t size) {
  *   For instance: setDataPattern(0b11011101) or setDataPattern(0xDD) or setDataPattern(221)
  *   Will result in data[] being set to {1, 1, 0, 1, 1, 1, 0, 1}
  */
-void setDataPattern(uint16_t newDataPattern) {
+void setDataPattern(uint32_t newDataPattern) {
     for(uint8_t i=0; i<DATA_LENGTH; i++) {
         // To set the left most array element (element 0), you need to address
         // the left most bit (bit 7 in an 8 bit number). Bit 0 is the right most bit.
@@ -88,7 +92,7 @@ void stepThroughDataPatterns(uint16_t repeatEachPatternNTimes) {
     for(uint16_t currPattern = firstPattern; currPattern <= lastPattern; currPattern++) {
         for(uint16_t repeatNum = 0; repeatNum < repeatEachPatternNTimes; repeatNum++) {
             setDataPattern(currPattern);
-            transmitBits(&preamble[0], sizeof(preamble));
+            transmitBits(&preamble[0], sizeof(preamble));       // Comment this line out to skip preamble
             transmitBits(&data[0], sizeof(data));
             transmitBits(&delayBetweenTransmissions[0], sizeof(delayBetweenTransmissions));
         }


### PR DESCRIPTION
Two commits:

 1. I've modified the setDataPattern so that it will take up to a 32-bit number. You could now skip the pre-amble all together and just brute force all of your bits (20 preamble bits and 8 data bits: treat it as 28 data bits with no preamble).
 2. You may have noticed a series of pesky compiler warnings when you compile. Many of those are MCC's fault (shame!) but some were mine. The compiler was complaining about variables that could be tagged as "const". const lets the compiler know those aren't going to change. So a "const" argument to a function is telling the compiler that the value won't change. So I changed two things to be const: the first is the pointer argument to setDataPattern. I made it "const bool*" meaning "that's pointing to a bool that the function is not going to change". The second change is that I made arrayStartPtr a "const bool*" meaning "that is a pointer that is pointing to a bool value that will not be changed via accessing this pointer. However, the pointer variable itself may change (it could point to a different location." This opens a can of worms to a subject that I think is fun: `bool*` vs `const bool*` vs `bool* const` vs `const bool* const`! [This StackExchange](https://stackoverflow.com/questions/4949254/const-char-const-versus-const-char) explains the matter well, and is a post that I reference often.  Anyway, I made the change because a) it is more explicit, b) now the compiler is more likely to catch you doing something you shouldn't with those variables, c) it got rid of compiler warnings. One should always strive for 0 compiler warnings! They're there for a reason and provide excellent guidance to write better code!

Anyway, snuck that second commit in on this unrelated PR