### PR TITLE
Pausing bit timer

### DIFF
--- a/include/addresses.h
+++ b/include/addresses.h
@@ -1,0 +1,8 @@
+#define DATA_LENGTH   30                 // Number of bits transmitted in a packet
+
+#if DATA_LENGTH > 32
+    #error "Data length has to be 32 bits or less"
+#endif
+
+#define ADDRESS_76  0b111011100011101110001011010010
+#define ADDRESS_92  0b111011000011101100001101110100

--- a/main.c
+++ b/main.c
@@ -1,30 +1,19 @@
 #include "mcc_generated_files/mcc.h"
+#include "addresses.h"
 
 // ========== DEFINES ==========
-#define DATA_LENGTH   30                 // Number of bits transmitted in a packet (not including preamble))
-//#define DEFAULT_DATA  0b1011010010        // Default Data to transmit 76
-#define DEFAULT_DATA  0b1101110100        // Default Data to transmit 92
+#define DEFAULT_DATA                    ADDRESS_92  // Default address to transmit
+#define TIME_BETWEEN_TRANSMISSIONS_US   6750        // Time between transmissions (in us)
+
 #define LED_PIN     LATAbits.LATA3      // Write to this to force the pin high (1) or low (0)
 #define PWM_EN      PWM3CONbits.EN      // Enables (1) or Disables (0) the PWM Output
 
-#if DATA_LENGTH > 32
-    #error "Data length has to be 32 bits or less"
-#endif
- 
 
 // ========== GLOBAL VARIABLES ==========
-//const bool preamble[] = {1, 1, 1, 0, 1, 1, 1, 0, 0, 0,
-//                         1, 1, 1, 0, 1, 1, 1, 0, 0, 0};       // Preamble 76
-//
-//
-//
-
-const bool preamble[] = {1, 1, 1, 0, 1, 1, 0, 0, 0, 0,
-                         1, 1, 1, 0, 1, 1, 0, 0, 0, 0};       // Preamble 92
-bool data[DATA_LENGTH] = {0};                                 // Data of our packet                             
-const bool delayBetweenTransmissions[50] = {0};               // Fill an array of zeros. 61 was first value
-const bool* arrayStartPtr = NULL;                             // Points to the beginning of an array
-uint8_t bitIndex = 0;                                         // Keeps track of our bit position
+bool data[DATA_LENGTH] = {0};                                                   // Data of our packet                             
+const bool delayBetweenTransmissions[TIME_BETWEEN_TRANSMISSIONS_US/135] = {0};  // Fill an array of zeros
+const bool* arrayStartPtr = NULL;                                               // Points to the beginning of an array
+uint8_t bitIndex = 0;                                                           // Keeps track of our bit position
 
 
 // ========== FUNCTION PROTOTYPES ==========

--- a/main.c
+++ b/main.c
@@ -43,6 +43,7 @@ void main(void)
     TMR0_Initialize();
     
     TMR0_SetInterruptHandler(bitTimerInterrupt);
+    TMR0_StopTimer();                               // Begin with bit timer stopped
 
     // Enable the Global Interrupts
     INTERRUPT_GlobalInterruptEnable();
@@ -77,7 +78,10 @@ void bitTimerInterrupt() {
 void transmitBits(const bool* arrayStart, uint8_t size) {
   bitIndex = 0;               // Re-initialize bit index
   arrayStartPtr = arrayStart; // Point to the start of the array we want to transmit
+  
+  TMR0_StartTimer();          // Start bit timer
   while(bitIndex < size);     // Wait here until the bit index reaches the end of the array
+  TMR0_StopTimer();           // Stop bit timer
 }
 
 /* Loads data[] with bools to correspond to an input

--- a/main.c
+++ b/main.c
@@ -10,8 +10,7 @@
 
 
 // ========== GLOBAL VARIABLES ==========
-bool data[DATA_LENGTH] = {0};                                                   // Data of our packet                             
-const bool delayBetweenTransmissions[TIME_BETWEEN_TRANSMISSIONS_US/135] = {0};  // Fill an array of zeros
+bool data[DATA_LENGTH + TIME_BETWEEN_TRANSMISSIONS_US/135] = {0};               // Data of our packet
 const bool* arrayStartPtr = NULL;                                               // Points to the beginning of an array
 uint8_t bitIndex = 0;                                                           // Keeps track of our bit position
 
@@ -83,7 +82,6 @@ void stepThroughDataPatterns(uint16_t repeatEachPatternNTimes) {
         for(uint16_t repeatNum = 0; repeatNum < repeatEachPatternNTimes; repeatNum++) {
             setDataPattern(currPattern);
             transmitBits(&data[0], sizeof(data));
-            transmitBits(&delayBetweenTransmissions[0], sizeof(delayBetweenTransmissions));
         }
     }
 }

--- a/main.c
+++ b/main.c
@@ -54,16 +54,7 @@ void main(void)
     // Set the data pattern
     setDataPattern(DEFAULT_DATA);
 
-   // while (1)
-    //{
-    //  transmitBits(&preamble[0], sizeof(preamble));
-    //  transmitBits(&data[0], sizeof(data));
-    //  transmitBits(&delayBetweenTransmissions[0], sizeof(delayBetweenTransmissions));
-    //}
-    
-    // Or
-    
-     while(1) {
+    while(1) {
        stepThroughDataPatterns(1);       // Repeat each pattern 10 times
      }
 }
@@ -102,7 +93,6 @@ void stepThroughDataPatterns(uint16_t repeatEachPatternNTimes) {
     for(uint32_t currPattern = firstPattern; currPattern <= lastPattern; currPattern++) {
         for(uint16_t repeatNum = 0; repeatNum < repeatEachPatternNTimes; repeatNum++) {
             setDataPattern(currPattern);
-           // transmitBits(&preamble[0], sizeof(preamble));       // Comment this line out to skip preamble
             transmitBits(&data[0], sizeof(data));
             transmitBits(&delayBetweenTransmissions[0], sizeof(delayBetweenTransmissions));
         }

--- a/nbproject/configurations.xml
+++ b/nbproject/configurations.xml
@@ -15,6 +15,7 @@
         <itemPath>mcc_generated_files/tmr0.h</itemPath>
         <itemPath>mcc_generated_files/interrupt_manager.h</itemPath>
       </logicalFolder>
+      <itemPath>include/addresses.h</itemPath>
     </logicalFolder>
     <logicalFolder name="LinkerScript"
                    displayName="Linker Files"
@@ -94,7 +95,7 @@
         <property key="default-char-type" value="true"/>
         <property key="define-macros" value=""/>
         <property key="disable-optimizations" value="true"/>
-        <property key="extra-include-directories" value=""/>
+        <property key="extra-include-directories" value="include"/>
         <property key="favor-optimization-for" value="-speed,+space"/>
         <property key="garbage-collect-data" value="true"/>
         <property key="garbage-collect-functions" value="true"/>


### PR DESCRIPTION
We can pause the bit timer when we don't mean to be transmitting bits. This will fix the issue of transmitting uninitialized bits while we're doing math. Also, some refactoring considering the addresses don't follow the original "preamble then data" structure we originally thought 