### PR TITLE
Calculating next address

### DIFF
--- a/main.c
+++ b/main.c
@@ -38,6 +38,7 @@ void main(void)
     TMR0_Initialize();
     
     TMR0_SetInterruptHandler(bitTimerInterrupt);
+    PWM_EN = false;                                 // Begin with LED off
     TMR0_StopTimer();                               // Begin with bit timer stopped
 
     // Enable the Global Interrupts
@@ -48,6 +49,10 @@ void main(void)
     
     // Set the data pattern
     setDataPattern(DEFAULT_DATA, DATA_LENGTH, currArrayStartPtr);
+    
+    // Send a known good address once
+    beginTransmission();
+    waitForTransmissionFinish();
 
     while(1) {
         stepThroughDataPatterns(0, ((1UL<<DATA_LENGTH) - 1), 10);

--- a/main.c
+++ b/main.c
@@ -3,12 +3,12 @@
 
 // ========== DEFINES ==========
 #define DEFAULT_DATA                    ADDRESS_92  // Default address to transmit
-#define TIME_BETWEEN_TRANSMISSIONS_US   6750        // Time between transmissions (in us)
+#define TRANSMISSION_INTERVAL           10800       // Time between transmissions (in us)
 
 #define LED_PIN     LATAbits.LATA3      // Write to this to force the pin high (1) or low (0)
 #define PWM_EN      PWM3CONbits.EN      // Enables (1) or Disables (0) the PWM Output
 
-#define BITS_PER_TRANSMISSION   (DATA_LENGTH + TIME_BETWEEN_TRANSMISSIONS_US/135)
+#define BITS_PER_TRANSMISSION   (TRANSMISSION_INTERVAL/135)
 
 
 // ========== GLOBAL VARIABLES ==========


### PR DESCRIPTION
Lots of great stuff in this one. Probably worth re-reading all of the code because things have changed quite a bit. But this should make many things much better:

 1. Solving the "microcontroller delays because it's calculating the next transmission" problem. Now there are two arrays. One is for the current transmission, then while that data is being sent, it sets up the second array with the next address. When it's done with one address, it swaps over to the other array. No more "calculation delay"
 2. Solving the "delays are limited by the microcontroller's small memory" problem. As opposed to having a byte of memory per delay bit, we can just decrement a counter. Delay to your heart's content now.

Also a few minor quality of life improvements:

 1. As opposed to specifying how much delay you want between transmissions, you just specify how often you want a transmission to start.
 2. stepThroughDataPatterns now accepts a start and finish address as arguments. Just pass it where you want to start and end.
 3. It starts out by transmitting a known good address. Hopefully this should make timing easier by keeping everything relative to when the microcontroller starts.
 4. Function descriptions. In case there's a piece of the code that you don't understand, hopefully the description can fill that hole for you so that you can keep up with the rest of the code.